### PR TITLE
Fix streaming scroll and reduce flashing

### DIFF
--- a/webui/index.js
+++ b/webui/index.js
@@ -243,6 +243,11 @@ function setMessage(id, type, heading, content, temp, kvps = null) {
         if (type === 'user') {
             return; // Skip re-rendering
         }
+        const span = messageContainer.querySelector('.msg-content span');
+        if (span) {
+            msgs.updateMessageContent(messageContainer, content);
+            return;
+        }
         // For other types, update the message
         messageContainer.innerHTML = '';
     } else {

--- a/webui/js/messages.js
+++ b/webui/js/messages.js
@@ -1595,7 +1595,7 @@ async function copyText(text, element) {
   }
 }
 
-function convertHTML(str) {
+export function convertHTML(str) {
   if (typeof str !== "string") str = JSON.stringify(str, null, 2);
 
   let result = escapeHTML(str);
@@ -1637,6 +1637,17 @@ function convertPathsToLinks(str) {
   const regex = new RegExp(`(?<=${prefix})\\/${folder}*${file}${suffix}`, "g");
 
   return str.replace(regex, generateLinks);
+}
+
+export function updateMessageContent(container, content) {
+  const span = container.querySelector('.msg-content span');
+  const msg = container.querySelector('.message');
+  if (!span || !msg) return;
+  const atBottom = msg.scrollTop + msg.clientHeight >= msg.scrollHeight - 1;
+  span.innerHTML = convertHTML(content);
+  if (atBottom) {
+    msg.scrollTop = msg.scrollHeight;
+  }
 }
 
 // Removed broken inline copy system - using original copy buttons instead


### PR DESCRIPTION
## Summary
- keep scroll position on streaming updates
- update message content smoothly to avoid flashing

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_684df1ae1e44833087ff01b5493a95da