### PR TITLE
Fix message height toggle

### DIFF
--- a/webui/index.js
+++ b/webui/index.js
@@ -890,6 +890,10 @@ export const setContext = function (id) {
     // Clear the chat history immediately to avoid showing stale content
     chatHistory.innerHTML = "";
 
+    // Reset per-message preferences on context switch
+    resetMessagePreferences();
+    updateAllButtonStates();
+
     // Update both selected states if Alpine is available
     if (window.Alpine) {
         try {
@@ -1000,6 +1004,15 @@ function updateAllButtonStates() {
                 }
             }
         }
+    });
+}
+
+// Clear per-message preferences from localStorage
+function resetMessagePreferences() {
+    const types = ['agent','response','tool','code_exe','browser','info','warning','error','user','default'];
+    types.forEach(t => {
+        localStorage.removeItem(`msgHidden_${t}`);
+        localStorage.removeItem(`msgFullHeight_${t}`);
     });
 }
 

--- a/webui/js/messages.js
+++ b/webui/js/messages.js
@@ -810,12 +810,13 @@ function createModernButton(buttonType, handler) {
 function updateButtonState(button, isActive, type, buttonType) {
   const isFixedHeightGlobal = localStorage.getItem('fixedHeight') === 'true';
   if (buttonType === 'height') {
-    // Minimal fix: when fixed height is OFF, use DOM state for active effect
+    // When global fixed height is OFF, determine active state from DOM
     if (!isFixedHeightGlobal) {
       const messageSelector = getMessageSelectorForType(type);
       const firstMsg = document.querySelector(messageSelector);
       if (firstMsg) {
-        isActive = firstMsg.classList.contains('message-compact');
+        // Active (compress icon) when message is expanded
+        isActive = firstMsg.classList.contains('message-expanded');
       }
     }
   }


### PR DESCRIPTION
## Summary
- reset per-message preferences when chat context changes
- show correct icon for message height when not using global fixed height

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6850c7768bb083309ef6a9e3d4494404